### PR TITLE
Manually validate parser options

### DIFF
--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -56,7 +56,7 @@ def test_author_forbidden_but_present():
 
 
 def test_author_invalid_attribute():
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         check('Jon Parise', attribute='invalid')
 
 
@@ -75,5 +75,5 @@ def test_author_pattern_not_matched():
 
 
 def test_author_pattern_invalid_regex():
-    with pytest.raises(SystemExit):
+    with pytest.raises(ValueError):
         check('Jon Parise', pattern=r'[[[')


### PR DESCRIPTION
The pep8 package unfortunately re-parses configuration file options and
doesn't recognize optparse's "advanced" option types, like 'choices' and
'callback'. While using these options from the command line worked great, pep8
would blow up when it encounted them in the configuration file.

We now parse and validate option values in the `parse_options()` plugin hook.