### PR TITLE
Update ast.Constant value for Python 3.14

### DIFF
--- a/flake8_author.py
+++ b/flake8_author.py
@@ -101,4 +101,4 @@ class Checker(object):
                 for author in ast.literal_eval(node.value):
                     yield from self._match_author_pattern(author, node)
             else:
-                yield from self._match_author_pattern(node.value.s, node)
+                yield from self._match_author_pattern(node.value.value, node)


### PR DESCRIPTION
> Attribute s is deprecated and will be removed in Python 3.14; use value instead