### PR TITLE
Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,0 @@
-include CHANGES.rst
-include LICENSE
-include README.rst
-
-recursive-include tests *
-recursive-exclude * *.py[co]


### PR DESCRIPTION
This is no longer needed now that we're using a common src layout. setuptools will find all of these files automatically.